### PR TITLE
Corrigido titulo da pagina aparecer undefined quando entra no site co…

### DIFF
--- a/source/javascripts/app/_toc.js
+++ b/source/javascripts/app/_toc.js
@@ -61,6 +61,9 @@
 
       // Catch the initial load case
       if (currentTop == scrollOffset && !loaded) {
+        if (window.location.hash.charAt(window.location.hash.length - 1) === '/')
+          window.location.hash = window.location.hash.slice(0, -1);
+
         best = window.location.hash;
         loaded = true;
       }


### PR DESCRIPTION
Decidi fazer uma alteração no código fonte do Slate ao invés de atualizar. A nova versão deles não garante que o problema se resolva, e ela muda muita coisa em vários arquivos, então teria que ser refatorado todo o projeto, basicamente. Da maneira que eu implementei, ele só corta fora a '/' da URL, o que é uma solução mais elegante do que tentar mostrar o titulo correto mesmo com a barra(porque o código foi feito com a expectativa que não vai ter nenhuma barra no final da url)